### PR TITLE
Changed minor things in KDS problem diagnose

### DIFF
--- a/projects/org.highmed/KDS/diagnose/KDS_problem_diagnose.yml
+++ b/projects/org.highmed/KDS/diagnose/KDS_problem_diagnose.yml
@@ -93,8 +93,8 @@ mappings:
       mappings:
         - name: "coding"
           with:
-            fhir: "$fhirRoot.coding"
-            openehr: "$openehrRoot"
+            fhir: "coding"
+            openehr: "$archetype"
             type: "NONE"
           fhirCondition:
             targetRoot: "coding"
@@ -105,7 +105,7 @@ mappings:
             mappings:
               - name: "codingSystem"
                 with:
-                  fhir: "coding"
+                  fhir: "$fhirRoot"
                 manual:
                   - name: "system"
                     fhir:

--- a/projects/org.highmed/KDS/diagnose/KDS_problem_diagnose.yml
+++ b/projects/org.highmed/KDS/diagnose/KDS_problem_diagnose.yml
@@ -94,7 +94,7 @@ mappings:
         - name: "coding"
           with:
             fhir: "coding"
-            openehr: "$archetype"
+            openehr: "$reference"
             type: "NONE"
           fhirCondition:
             targetRoot: "coding"


### PR DESCRIPTION
- no need for the $fhirRoot
- 'coding' in "codingSystem" mapping had to be changed from 'coding' to $fhirRoot, since parent is already addressing a coding