### PR TITLE
Specify json-schema for KDS_diagnose.context.yaml

### DIFF
--- a/projects/org.highmed/KDS/diagnose/KDS_diagnose.context.yaml
+++ b/projects/org.highmed/KDS/diagnose/KDS_diagnose.context.yaml
@@ -1,3 +1,4 @@
+$schema: https://raw.githubusercontent.com/SevKohler/FHIRconnect-spec/refs/heads/main/modules/ROOT/attachments/contextual-mapping.schema.json
 grammar: FHIRConnect/v1.0.0
 type: context
 metadata:


### PR DESCRIPTION
example for all the mappings
The ‘schema’ keyword is a non-standard way for specifying a schema file for a json file/object. Supported by at least VScode. 
if it works I’d suggest adding it to all mappings, and specifying it as a convention or rule in the fhir-connect spec. 